### PR TITLE
Disable firmware being compiled inside kernel

### DIFF
--- a/arch/arm64/configs/android_rpi_defconfig
+++ b/arch/arm64/configs/android_rpi_defconfig
@@ -1755,8 +1755,8 @@ CONFIG_PREVENT_FIRMWARE_BUILD=y
 # Firmware loader
 #
 CONFIG_FW_LOADER=y
-CONFIG_EXTRA_FIRMWARE="regulatory.db regulatory.db.p7s BCM4345C0.hcd BCM4345C5.hcd brcmfmac43455-sdio.bin brcmfmac43455-sdio.clm_blob brcmfmac43455-sdio.txt brcmfmac43456-sdio.bin brcmfmac43456-sdio.clm_blob brcmfmac43456-sdio.txt"
-CONFIG_EXTRA_FIRMWARE_DIR="../vendor/brcm/proprietary/lib/firmware"
+CONFIG_EXTRA_FIRMWARE=""
+CONFIG_EXTRA_FIRMWARE_DIR=""
 # CONFIG_FW_LOADER_USER_HELPER is not set
 # CONFIG_FW_LOADER_COMPRESS is not set
 # CONFIG_FW_CACHE is not set


### PR DESCRIPTION
Change-Id: Idaa7aaa2f2198dd0cb90c7ea300b3b74f369eb37

We are removing firmware directory to disable it from being compiled inside the kernel. This way we are able to replace firmware without compiling the whole kernel.